### PR TITLE
Align site content with Rainde reference

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,11 @@
     <header class="site-header" id="top">
       <div class="container">
         <div class="branding">
-          <span class="logo-mark">R</span>
+          <img
+            src="reference/banner/imgBanner/banner1.jpg"
+            alt="Logotipo de Rainde"
+            class="logo-image"
+          />
           <span class="logo-text">Rainde</span>
         </div>
         <button class="menu-toggle" aria-expanded="false" aria-controls="primary-navigation">
@@ -101,42 +105,48 @@
         </div>
       </section>
 
-      <section class="section" id="nosotros">
-        <div class="container split">
-          <div class="section-heading">
-            <span class="eyebrow">Nosotros</span>
-            <h2>Innovación mexicana en rastreo y control de activos</h2>
-            <p>
-              Rainde surge a finales de 2008 ofreciendo servicios de diseño, implementación y comercialización de soluciones integrales de rastreo y control de activos móviles en tiempo real para la transportación de personas, valores y bienes.
-            </p>
-            <p>
-              Somos una empresa de tecnologías de la información que desarrolla sistemas inalámbricos con creatividad y flexibilidad, capaces de adaptarse a los procesos de cada negocio y respaldados por investigación aplicada en telecomunicaciones.
-            </p>
-          </div>
-          <div class="platform-card">
-            <h3>Misión</h3>
-            <p>Proporcionar sistemas de administración y control de activos en tiempo real que protejan los valores y recursos de nuestros clientes sin importar su ubicación.</p>
-            <h3>Política de calidad</h3>
-            <p>Aseguramos la disponibilidad de nuestros servicios en cualquier lugar donde nuestros clientes cuenten con conexión a internet.</p>
-            <div class="tags">
-              <span>Servicio</span>
-              <span>Respeto</span>
-              <span>Responsabilidad</span>
-              <span>Creatividad</span>
-              <span>Tolerancia</span>
-              <span>Integridad</span>
+        <section class="section" id="nosotros">
+          <div class="container split">
+            <div class="section-heading">
+              <span class="eyebrow">Nosotros</span>
+              <h2>Sistemas informáticos de rastreo satelital y control de activos</h2>
+              <p>
+                RAINDE surge a finales del 2008 ofreciendo servicios de diseño, implementación y comercialización de soluciones integrales de rastreo y control de activos móviles en tiempo real para la transportación de personas, valores y bienes.
+              </p>
+              <p>
+                Somos una empresa del servicio de <strong>TECNOLOGÍAS DE INFORMACIÓN</strong> que ofrece soluciones tecnológicas de diseño de sistemas y control de activos vía inalámbrica enfocadas en controlar y optimizar el uso de recursos de nuestros clientes de forma creativa y flexible, de acuerdo a sus necesidades.
+              </p>
+              <p>
+                RAINDE promueve la investigación aplicada en los más recientes avances tecnológicos en telecomunicación para contribuir en la administración de los recursos de sus clientes en cualquier parte del mundo.
+              </p>
+            </div>
+            <div class="platform-card">
+              <h3>¿Por qué elegir RAINDE?</h3>
+              <p>
+                Ofrecemos soluciones de software, consultoría, soporte e infraestructura viables, concretas y a la medida de <strong>tu negocio</strong>.
+              </p>
+              <div class="tags">
+                <span>Software</span>
+                <span>Consultoría</span>
+                <span>Soporte</span>
+                <span>Infraestructura</span>
+                <span>Investigación aplicada</span>
+                <span>Flexibilidad</span>
+              </div>
+              <p class="platform-note">
+                Cada proyecto se adapta a tus procesos para proteger tus valores y recursos con disponibilidad global.
+              </p>
             </div>
           </div>
-        </div>
-      </section>
+        </section>
 
       <section class="section" id="soluciones">
         <div class="container">
           <div class="section-heading">
             <span class="eyebrow">Soluciones</span>
-            <h2>Plataformas y servicios listos para tu flotilla</h2>
+            <h2>La misma oferta de RAINDE con una presentación moderna</h2>
             <p>
-              Integramos administración de viajes, rastreo satelital y soporte especializado para que cada activo se controle en un mismo centro de mando.
+              Recuperamos los servicios del sitio original para que identifiques rápidamente la solución que necesitas.
             </p>
           </div>
           <div class="grid features">
@@ -148,14 +158,14 @@
                   <path d="M8 14h4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" />
                 </svg>
               </div>
-              <h3>Administración de Flotillas (ERaindeFLEET)</h3>
+              <h3>Sistemas de Administración de flotilla Personalizada</h3>
               <p>
-                Optimiza viajes, personal, finanzas, despachos y proveedores con un sistema configurable diseñado para tus procesos.
+                Sistema administrador configurable que optimiza los viajes, el personal, las finanzas, las liquidaciones, los despachos, el rastreo y los proveedores.
               </p>
               <ul>
-                <li>Acceso web seguro con reportes imprimibles.</li>
-                <li>Alertas automatizadas y seguimiento puntual de cada viaje.</li>
-                <li>Escalabilidad que crece con tus operaciones.</li>
+                <li>Acceso web con seguridad de datos y reportes imprimibles.</li>
+                <li>Procesos rápidos disponibles desde cualquier equipo conectado a Internet.</li>
+                <li>Adaptable a tus procesos administrativos para crecer sin límites.</li>
               </ul>
             </article>
             <article>
@@ -165,14 +175,14 @@
                   <path d="M12 7v5l3 3" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" />
                 </svg>
               </div>
-              <h3>Rastreo Inteligente</h3>
+              <h3>Localización Satelital</h3>
               <p>
-                Monitorea en tiempo real cualquier activo, vehículo o maquinaria con historial, ubicación actual y alertas fuera de ruta.
+                Rastreo y localización satelital en cualquier tipo de activo, vehículo o maquinaria que necesites monitorear de manera remota.
               </p>
               <ul>
-                <li>Geocercas, puntos de interés y control de usuarios.</li>
-                <li>Conexión directa con ECM y control de combustible.</li>
-                <li>Reportes de recorridos y rendimientos reales.</li>
+                <li>Historial, ubicación actual y alertas fuera de ruta.</li>
+                <li>Control de usuarios, geocercas y puntos de interés.</li>
+                <li>Conexión directa con ECM, control de combustible y reportes de recorridos reales.</li>
               </ul>
             </article>
             <article>
@@ -182,14 +192,31 @@
                   <path d="M14 14l6 6" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" />
                 </svg>
               </div>
-              <h3>Soporte y operación 24/7</h3>
+              <h3>Desarrollo de Software</h3>
               <p>
-                Un equipo técnico profesional atiende sistemas, redes e infraestructura con planes ajustados a tus necesidades.
+                ¿Quieres que tu empresa se adapte a un sistema o prefieres un sistema que te ayude a optimizar los procesos de tu empresa?
               </p>
               <ul>
-                <li>Asistencia eficiente para tu parque tecnológico.</li>
-                <li>Opciones viables según tu operación.</li>
-                <li>Atención sin límites, disponible 24 x 7.</li>
+                <li>Sistemas de software a la medida con acompañamiento experto.</li>
+                <li>Integración entre plataformas para disminuir errores.</li>
+                <li>Automatización que responde a tu operación diaria.</li>
+              </ul>
+            </article>
+            <article>
+              <div class="icon">
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M4 6l8-4 8 4v6c0 4.4-3.6 8-8 8s-8-3.6-8-8z" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linejoin="round" />
+                  <path d="M9 12l2 2 4-4" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" />
+                </svg>
+              </div>
+              <h3>Soporte Dedicado</h3>
+              <p>
+                Nuestro equipo técnico de profesionales se relaciona con tu negocio para satisfacer de manera eficiente la asistencia técnica de sistemas, redes o infraestructura.
+              </p>
+              <ul>
+                <li>Opciones de soporte viables según la necesidad de tu negocio.</li>
+                <li>Respaldo para equipos de cómputo, redes y servicios informáticos.</li>
+                <li>Atención sin límites, <strong>24 x 7</strong>.</li>
               </ul>
             </article>
           </div>
@@ -202,17 +229,27 @@
             <span class="eyebrow">RaindeFLEET</span>
             <h2>Un sistema integral para administrar cada detalle de tu flotilla</h2>
             <p>
-              ERaindeFLEET reúne seguridad, rapidez y facilidad de uso para automatizar la administración de viajes, liquidaciones y recursos desde un entorno web.
+              Sistema Administrador de Flotillas que optimiza el proceso de administración de los diferentes tipos de transporte, así como del personal de la empresa, finanzas, liquidaciones, despachos, rastreo y proveedores. Además, se configura fácilmente para adaptarse a tus procesos administrativos.
+            </p>
+            <p>
+              ERaindeFLEET cuenta con seguridad de acceso, seguridad de datos, interfaces amigables, reportes imprimibles para su documentación, rapidez en sus procesos y acceso web para una consulta sencilla desde cualquier equipo con conexión a Internet.
             </p>
             <ul class="checklist">
-              <li>Seguridad en el acceso y resguardo de datos.</li>
-              <li>Crecimiento sin límites conforme escala tu operación.</li>
-              <li>Autonomía y centinelas para monitorear cada unidad.</li>
-              <li>Herramientas de despacho con reportes en tiempo real y correo electrónico.</li>
-              <li>Alertas contra desviaciones de ETA y eventos críticos.</li>
-              <li>Finanzas, liquidaciones y mantenimiento preventivo integrados.</li>
-              <li>Gestión completa de proveedores y almacenes.</li>
+              <li>SEGURIDAD</li>
+              <li>CRECIMIENTO SIN LIMITES</li>
+              <li>AUTONOMIA</li>
+              <li>CENTINELAS</li>
+              <li>DESPACHO</li>
+              <li>REPORTES TIEMPO REAL HTML Y CORREO ELECTRONICO</li>
+              <li>FACILIDAD DE USO</li>
+              <li>ALERTAS E-MAIL VS ETA</li>
+              <li>PERSONALIZABLE</li>
+              <li>FINANZAS</li>
+              <li>MANTENIMIENTO</li>
+              <li>PROVEEDORES</li>
+              <li>ALMACENES</li>
             </ul>
+            <a class="button ghost more-info" href="#contacto">Más información</a>
           </div>
           <div class="platform-card">
             <h3>Componentes clave</h3>
@@ -237,57 +274,40 @@
       </section>
 
       <section class="section" id="rastreointeligente">
-        <div class="container">
-          <div class="section-heading">
+        <div class="container split">
+          <div>
             <span class="eyebrow">Rastreo Inteligente</span>
-            <h2>Monitoreo satelital con información precisa y accionable</h2>
+            <h2>Rastreo y localización satelital en cualquier tipo de activo</h2>
             <p>
-              Visualiza la ubicación actual, el historial de recorridos y los eventos críticos de cada activo para reaccionar a tiempo y proteger tu operación.
+              Rastreo y localización satelital en cualquier tipo de activo, vehículo o maquinaria, todo lo que quieras monitorear de manera remota con información actualizada en tiempo real.
             </p>
+            <ul class="checklist columns">
+              <li>HISTORIAL</li>
+              <li>UBICACIÓN ACTUAL</li>
+              <li>FUERA DE RUTA</li>
+              <li>CONTROL DE USUARIOS</li>
+              <li>GEOCERCAS</li>
+              <li>PUNTOS DE INTERES</li>
+              <li>ALERTAS</li>
+              <li>CONEXION DIRECTA CON ECM</li>
+              <li>CONTROL COMBUSTIBLE</li>
+              <li>RECORRIDOS REALES</li>
+              <li>RENDIMIENTOS REALES</li>
+            </ul>
+            <a class="button ghost more-info" href="#contacto">Más información</a>
           </div>
-          <div class="grid insights-grid">
-            <article>
-              <h3>Historial y análisis</h3>
-              <p>Consulta recorridos reales y rendimientos para documentar cada trayecto.</p>
-              <dl>
-                <div>
-                  <dt>Historial</dt>
-                  <dd>Trayectorias completas con tiempos y distancias.</dd>
-                </div>
-                <div>
-                  <dt>Reportes</dt>
-                  <dd>Información lista para exportar y compartir.</dd>
-                </div>
-              </dl>
-            </article>
-            <article>
-              <h3>Control operativo</h3>
-              <p>Define reglas por geocercas y recibe alertas ante desvíos o paradas no previstas.</p>
-              <dl>
-                <div>
-                  <dt>Geocercas</dt>
-                  <dd>Delimita zonas seguras y puntos de interés.</dd>
-                </div>
-                <div>
-                  <dt>Fuera de ruta</dt>
-                  <dd>Centinelas que notifican variaciones en la ruta planeada.</dd>
-                </div>
-              </dl>
-            </article>
-            <article>
-              <h3>Integración vehicular</h3>
-              <p>Conecta la plataforma al ECM para controlar combustible y desempeño.</p>
-              <dl>
-                <div>
-                  <dt>ECM</dt>
-                  <dd>Lectura directa de datos del motor y diagnósticos.</dd>
-                </div>
-                <div>
-                  <dt>Combustible</dt>
-                  <dd>Seguimiento de consumo real con alertas configurables.</dd>
-                </div>
-              </dl>
-            </article>
+          <div class="platform-card">
+            <h3>Monitoreo 24/7</h3>
+            <p>
+              Define centinelas, recibe notificaciones por correo electrónico y actúa ante cualquier evento crítico para mantener tu operación bajo control.
+            </p>
+            <div class="tags">
+              <span>Alertas</span>
+              <span>Geocercas</span>
+              <span>Combustible</span>
+              <span>Reportes</span>
+            </div>
+            <p class="platform-note">Toda la información histórica queda disponible para documentar cada recorrido.</p>
           </div>
         </div>
       </section>
@@ -301,7 +321,25 @@
               Complementa tus sistemas con consultoría, integración y soluciones de infraestructura que mantienen tus procesos siempre disponibles.
             </p>
           </div>
-          <div class="grid features">
+          <div class="grid features services-grid">
+            <article>
+              <div class="icon">
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M4 5h16v14H4z" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linejoin="round" />
+                  <path d="M8 9h8v6H8z" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linejoin="round" />
+                  <path d="M8 5v4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" />
+                </svg>
+              </div>
+              <h3>Soporte dedicado</h3>
+              <p>
+                Nuestro equipo técnico de profesionales satisface de manera eficiente la asistencia técnica de tus equipos de cómputo, redes, sistemas informáticos o infraestructura.
+              </p>
+              <ul>
+                <li>Opciones de soporte viables según la necesidad de tu negocio.</li>
+                <li>Atención personalizada para mantener tus servicios disponibles.</li>
+                <li>Respuesta sin límites, <strong>24 x 7</strong>.</li>
+              </ul>
+            </article>
             <article>
               <div class="icon">
                 <svg viewBox="0 0 24 24" aria-hidden="true">
@@ -309,14 +347,12 @@
                   <path d="M9 12l2 2 4-4" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" />
                 </svg>
               </div>
-              <h3>Consultoría y diseño</h3>
-              <p>
-                Diseñamos, analizamos y reingenierizamos sistemas para que cada solución se ajuste a tu estrategia de negocio.
-              </p>
+              <h3>Consultoría</h3>
+              <p>Acompañamos a tu organización con servicios de diseño, reingeniería y análisis.</p>
               <ul>
-                <li>Diseño de soluciones a la medida.</li>
-                <li>Reingeniería de sistemas existentes.</li>
-                <li>Análisis funcional y técnico especializado.</li>
+                <li>Diseño de soluciones.</li>
+                <li>Reingeniería de sistemas.</li>
+                <li>Análisis especializado.</li>
               </ul>
             </article>
             <article>
@@ -327,14 +363,14 @@
                   <path d="M9 12h6" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" />
                 </svg>
               </div>
-              <h3>Infraestructura a la medida</h3>
+              <h3>Infraestructura</h3>
               <p>
-                Garantizamos seguridad y estabilidad para que tus servicios informáticos respondan a la demanda del mercado.
+                La seguridad y estabilidad en las empresas son vitales. Brindamos alternativas a la medida que dan soporte y calidad a tus procesos administrativos.
               </p>
               <ul>
-                <li>Evaluaciones de seguridad y disponibilidad.</li>
-                <li>Implementaciones alineadas a tus procesos.</li>
-                <li>Operaciones eficientes con calidad comprobada.</li>
+                <li>Seguridad y estabilidad para tu operación.</li>
+                <li>Implementaciones acordes a la demanda del mercado.</li>
+                <li>Procesos eficientes y de calidad.</li>
               </ul>
             </article>
             <article>
@@ -345,14 +381,32 @@
                   <path d="M12 9v6" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" />
                 </svg>
               </div>
-              <h3>Desarrollo e integración</h3>
+              <h3>Desarrollo de software</h3>
               <p>
-                Construimos software a la medida e integramos sistemas para que los datos se capturen una sola vez y lleguen a toda tu organización.
+                Si buscas un sistema que te ayude a optimizar los procesos de tu empresa, desarrollamos soluciones a la medida para que tu operación sea más eficiente.
               </p>
               <ul>
-                <li>Automatización de procesos críticos.</li>
-                <li>Conectividad entre plataformas existentes.</li>
-                <li>Escenarios personalizables para cada área.</li>
+                <li>Aplicaciones orientadas a tus procesos.</li>
+                <li>Acompañamiento experto durante el desarrollo.</li>
+                <li>Implementación con enfoque en resultados.</li>
+              </ul>
+            </article>
+            <article>
+              <div class="icon">
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M4 6h16v12H4z" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linejoin="round" />
+                  <path d="M4 10h16" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" />
+                  <path d="M10 14l3 3 3-3" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" />
+                </svg>
+              </div>
+              <h3>Integración de sistemas</h3>
+              <p>
+                La mejor manera de disminuir los errores es capturar la información una sola vez y actualizarla automáticamente en todos los sistemas restantes.
+              </p>
+              <ul>
+                <li>Conectamos tus plataformas existentes.</li>
+                <li>Automatizamos el flujo de datos.</li>
+                <li>Logramos continuidad operativa.</li>
               </ul>
             </article>
           </div>
@@ -363,109 +417,77 @@
         <div class="container">
           <div class="section-heading">
             <span class="eyebrow">Paquetes web</span>
-            <h2>Presencia digital lista para impulsar tu negocio</h2>
+            <h2>El mismo portafolio digital del sitio original</h2>
             <p>
-              Selecciona la opción que mejor se adapte a tu empresa o arma una propuesta personalizada con los módulos que necesites.
+              Elige uno de nuestros paquetes o arma tu propuesta solicitando la combinación exacta de módulos, galerías y formularios para tu negocio.
             </p>
           </div>
           <div class="grid insights-grid">
             <article>
               <h3>Paquete Mi Empresa</h3>
-              <p>Todo lo necesario para iniciar tu sitio corporativo.</p>
+              <p>Incluye lo necesario para publicar tu empresa en línea.</p>
               <ul>
-                <li>1 año de publicación en internet.</li>
-                <li>Dominio incluido y diseño de 7 módulos informativos.</li>
-                <li>Correo empresarial para tu equipo.</li>
+                <li>1 año de servicio de publicación en Internet.</li>
+                <li>Dominio del sitio.</li>
+                <li>Diseño de 7 módulos informativos.</li>
+                <li>Correo empresarial.</li>
               </ul>
             </article>
             <article>
               <h3>Paquete Mi Negocio Web</h3>
-              <p>Una experiencia optimizada para clientes en cualquier dispositivo.</p>
+              <p>Amplía tu presencia con un sitio optimizado para cualquier dispositivo.</p>
               <ul>
-                <li>1 año de hospedaje y dominio administrado.</li>
-                <li>7 módulos informativos con diseño profesional.</li>
-                <li>Correos empresariales y versión móvil del sitio.</li>
+                <li>1 año de servicio de publicación en Internet.</li>
+                <li>Dominio del sitio.</li>
+                <li>Diseño de 7 módulos informativos.</li>
+                <li>Correos empresariales.</li>
+                <li>Versión móvil.</li>
               </ul>
             </article>
             <article>
               <h3>Arma tu Paquete</h3>
-              <p>Cotiza un proyecto a la medida con los componentes que requieres.</p>
+              <p>Completa el formulario de cotización para definir cada componente.</p>
               <ul>
-                <li>Módulos informativos, galerías y formularios personalizables.</li>
-                <li>Banners animados, sistemas de administración y perfiles de usuarios.</li>
-                <li>Acompañamiento para publicar y gestionar tu sitio.</li>
+                <li>Módulos de información según lo que necesites.</li>
+                <li>Galerías de fotos y de videos.</li>
+                <li>Formularios, banners animados y sistemas de administración.</li>
+                <li>Perfiles de usuarios y apoyo para administrar tu sitio.</li>
               </ul>
             </article>
           </div>
         </div>
       </section>
 
-      <section class="section testimonials" id="valores">
+      <section class="section" id="valores">
         <div class="container">
           <div class="section-heading">
-            <span class="eyebrow">Valores</span>
-            <h2>Nuestro compromiso con clientes y colaboradores</h2>
+            <span class="eyebrow">Misión, Visión y Valores</span>
+            <h2>Compromiso de RAINDE con sus clientes</h2>
+            <p>
+              RAINDE trabaja con un marco de valores que respalda cada proyecto y asegura la disponibilidad de nuestros servicios para proteger los recursos de nuestros clientes en cualquier parte del mundo.
+            </p>
           </div>
-          <div class="carousel" role="list">
-            <article class="testimonial" role="listitem">
-              <p>Respondemos a las necesidades de nuestros clientes en el momento en que lo requieren.</p>
-              <div class="author">
-                <span class="avatar" aria-hidden="true">S</span>
-                <div>
-                  <strong>Servicio</strong>
-                  <span>Disponibilidad y acompañamiento oportuno.</span>
-                </div>
-              </div>
+          <div class="values-grid">
+            <article>
+              <h3>Misión</h3>
+              <p>
+                Proporcionar sistemas de administración y control de activos en tiempo real, que brinden una solución integral a nuestros clientes, contribuyendo a proteger sus valores y recursos desde cualquier parte del mundo.
+              </p>
             </article>
-            <article class="testimonial" role="listitem">
-              <p>Creemos en la importancia de la sociedad, el medio ambiente y el respeto a las leyes.</p>
-              <div class="author">
-                <span class="avatar" aria-hidden="true">R</span>
-                <div>
-                  <strong>Respeto</strong>
-                  <span>Diversidad de ideas que fortalece a nuestro equipo.</span>
-                </div>
-              </div>
+            <article>
+              <h3>Visión</h3>
+              <ul>
+                <li><strong>Servicio:</strong> Respondemos a las necesidades y requerimientos de nuestros clientes en el momento en que lo necesiten.</li>
+                <li><strong>Respeto:</strong> Creemos que la sociedad, el medio ambiente y las leyes son importantes; el derecho de pensar y actuar diferente nos enriquece.</li>
+                <li><strong>Responsabilidad:</strong> Somos personas de palabra y cumplimos nuestros compromisos con entusiasmo.</li>
+                <li><strong>Creatividad:</strong> Fomentamos ideas que rompen paradigmas y enriquecen nuestro trabajo.</li>
+                <li><strong>Tolerancia:</strong> Promovemos empatía y cooperación para lograr buena comunicación y trabajo en equipo.</li>
+                <li><strong>Integridad:</strong> Buscamos honestidad y congruencia en todas nuestras relaciones de trabajo.</li>
+              </ul>
             </article>
-            <article class="testimonial" role="listitem">
-              <p>Cumplimos nuestros compromisos con entusiasmo y constancia para alcanzar las metas.</p>
-              <div class="author">
-                <span class="avatar" aria-hidden="true">R</span>
-                <div>
-                  <strong>Responsabilidad</strong>
-                  <span>Palabra y acciones alineadas a cada proyecto.</span>
-                </div>
-              </div>
-            </article>
-            <article class="testimonial" role="listitem">
-              <p>Fomentamos ideas que rompen paradigmas y enriquecen nuestro trabajo diario.</p>
-              <div class="author">
-                <span class="avatar" aria-hidden="true">C</span>
-                <div>
-                  <strong>Creatividad</strong>
-                  <span>Innovación continua para nuestros clientes.</span>
-                </div>
-              </div>
-            </article>
-            <article class="testimonial" role="listitem">
-              <p>Promovemos la empatía y la cooperación para lograr comunicación y trabajo en equipo efectivos.</p>
-              <div class="author">
-                <span class="avatar" aria-hidden="true">T</span>
-                <div>
-                  <strong>Tolerancia</strong>
-                  <span>Relaciones que suman a cada proyecto.</span>
-                </div>
-              </div>
-            </article>
-            <article class="testimonial" role="listitem">
-              <p>Buscamos honestidad y congruencia en cada relación laboral y comercial.</p>
-              <div class="author">
-                <span class="avatar" aria-hidden="true">I</span>
-                <div>
-                  <strong>Integridad</strong>
-                  <span>Trabajo digno dentro del marco de la ley.</span>
-                </div>
-              </div>
+            <article>
+              <h3>Política de calidad</h3>
+              <p>Asegurar la disponibilidad de nuestro servicio en cualquier lugar donde se encuentre nuestro cliente con una conexión a Internet.</p>
             </article>
           </div>
         </div>
@@ -478,14 +500,30 @@
               <span class="eyebrow">Contacto</span>
               <h2>Conversemos sobre tus necesidades</h2>
               <p>
-                Solicita una demostración personalizada o comparte los retos de tu operación. Nuestro equipo te ayudará a elegir la solución adecuada.
+                <strong>Favor de llenar el formulario con sus datos para contactarlo.</strong> Estamos listos para ofrecerle la misma atención que en el sitio original.
               </p>
               <p>Teléfono oficina: <strong>449 996 7500</strong><br />Correo: <strong>ventas@rainde.net</strong></p>
             </div>
             <form class="cta-form" action="#" method="post">
               <div class="form-row">
                 <label for="name">Nombre completo</label>
-                <input type="text" id="name" name="name" placeholder="Nombre y apellido" required />
+                <input type="text" id="name" name="name" placeholder="Nombre completo" required />
+              </div>
+              <div class="form-row">
+                <label for="city">Ciudad</label>
+                <input type="text" id="city" name="city" placeholder="Ciudad" required />
+              </div>
+              <div class="form-row">
+                <label for="phone">Teléfono</label>
+                <input type="tel" id="phone" name="phone" placeholder="449 000 0000" required />
+              </div>
+              <div class="form-row">
+                <label for="mobile">Teléfono móvil</label>
+                <input type="tel" id="mobile" name="mobile" placeholder="Número móvil" />
+              </div>
+              <div class="form-row">
+                <label for="nextel">Nextel</label>
+                <input type="text" id="nextel" name="nextel" placeholder="ID Nextel" />
               </div>
               <div class="form-row">
                 <label for="email">Correo electrónico</label>
@@ -493,17 +531,11 @@
               </div>
               <div class="form-row">
                 <label for="company">Empresa</label>
-                <input type="text" id="company" name="company" placeholder="Nombre de la empresa" />
+                <input type="text" id="company" name="company" placeholder="Nombre de la empresa" required />
               </div>
               <div class="form-row">
-                <label for="fleet-size">Tamaño de la flotilla</label>
-                <select id="fleet-size" name="fleet-size">
-                  <option value="" disabled selected>Selecciona una opción</option>
-                  <option value="1-50">1-50 vehículos</option>
-                  <option value="51-250">51-250 vehículos</option>
-                  <option value="251-1000">251-1000 vehículos</option>
-                  <option value="1000+">Más de 1000 vehículos</option>
-                </select>
+                <label for="info">Información</label>
+                <textarea id="info" name="info" rows="4" placeholder="Cuéntanos qué información necesitas" required></textarea>
               </div>
               <button type="submit" class="button primary">Enviar mensaje</button>
             </form>
@@ -515,7 +547,7 @@
     <footer class="site-footer">
       <div class="container">
         <div class="footer-brand">
-          <span class="logo-mark">R</span>
+          <img src="reference/banner/imgBanner/banner1.jpg" alt="Logotipo de Rainde" class="logo-image" />
           <div>
             <span class="logo-text">Rainde</span>
             <p>Sistemas de administración de flotillas y rastreo inteligente.</p>

--- a/index.html
+++ b/index.html
@@ -1,13 +1,13 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="es">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta
       name="description"
-      content="NovaFleet is a modern fleet intelligence platform that unifies operations, maintenance, and customer experiences with predictive insights."
+      content="Rainde ofrece sistemas de administración de flotillas, rastreo inteligente, paquetes web y servicios de TI que protegen y optimizan los recursos de tu empresa."
     />
-    <title>NovaFleet Solutions</title>
+    <title>Rainde :: Sistemas de Administración de Flotillas</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
@@ -20,21 +20,23 @@
     <header class="site-header" id="top">
       <div class="container">
         <div class="branding">
-          <span class="logo-mark">N</span>
-          <span class="logo-text">NovaFleet</span>
+          <span class="logo-mark">R</span>
+          <span class="logo-text">Rainde</span>
         </div>
         <button class="menu-toggle" aria-expanded="false" aria-controls="primary-navigation">
-          <span class="sr-only">Toggle navigation</span>
+          <span class="sr-only">Abrir navegación</span>
           <span></span>
           <span></span>
           <span></span>
         </button>
-        <nav class="site-nav" id="primary-navigation" aria-label="Main">
-          <a href="#solutions">Solutions</a>
-          <a href="#platform">Platform</a>
-          <a href="#insights">Insights</a>
-          <a href="#contact">Contact</a>
-          <a class="cta" href="#demo">Book a Demo</a>
+        <nav class="site-nav" id="primary-navigation" aria-label="Principal">
+          <a href="#nosotros">Nosotros</a>
+          <a href="#soluciones">Soluciones</a>
+          <a href="#plataforma">RaindeFLEET</a>
+          <a href="#rastreointeligente">Rastreo</a>
+          <a href="#servicios">Servicios</a>
+          <a href="#paquetes">Paquetes Web</a>
+          <a class="cta" href="#contacto">Contáctanos</a>
         </nav>
       </div>
     </header>
@@ -43,46 +45,44 @@
       <section class="hero" id="hero">
         <div class="container">
           <div class="hero-content">
-            <div class="eyebrow">Connected Fleet Intelligence</div>
-            <h1>Orchestrate your entire fleet with one modern command center.</h1>
+            <div class="eyebrow">Sistemas de administración de flotillas</div>
+            <h1>Controla tus activos y operaciones en tiempo real con Rainde.</h1>
             <p>
-              NovaFleet provides a unified operating picture across vehicles, assets,
-              and field teams. Unlock predictive insights, automate compliance, and
-              deliver exceptional customer experiences with ease.
+              Rainde desarrolla soluciones inalámbricas que protegen tus recursos, automatizan la gestión de flotillas y brindan información oportuna para tomar decisiones desde cualquier lugar del mundo.
             </p>
             <div class="hero-actions">
-              <a class="button primary" href="#demo">Book a live demo</a>
-              <a class="button ghost" href="#solutions">Explore solutions</a>
+              <a class="button primary" href="#contacto">Solicitar una demostración</a>
+              <a class="button ghost" href="#soluciones">Conoce nuestras soluciones</a>
             </div>
             <dl class="hero-stats">
               <div>
-                <dt>45%</dt>
-                <dd>Average reduction in operating costs</dd>
+                <dt>2008</dt>
+                <dd>Más de una década creando sistemas de rastreo y control de activos.</dd>
               </div>
               <div>
-                <dt>99.8%</dt>
-                <dd>Platform uptime powered by resilient cloud architecture</dd>
+                <dt>24/7</dt>
+                <dd>Soporte, monitoreo y acompañamiento continuo para tu operación.</dd>
               </div>
               <div>
-                <dt>3.2M</dt>
-                <dd>Connected assets across logistics, energy, and public sector</dd>
+                <dt>1000+</dt>
+                <dd>Unidades monitoreadas con reportes, alertas y documentación en línea.</dd>
               </div>
             </dl>
           </div>
           <div class="hero-visual" aria-hidden="true">
             <div class="glass-card">
-              <h3>Live Fleet Pulse</h3>
+              <h3>Panel RaindeFLEET</h3>
               <div class="metric">
-                <span class="metric-label">Vehicles active</span>
+                <span class="metric-label">Unidades activas</span>
                 <span class="metric-value">128</span>
               </div>
               <div class="metric">
-                <span class="metric-label">On-time deliveries</span>
-                <span class="metric-value success">98%</span>
+                <span class="metric-label">Rutas monitoreadas</span>
+                <span class="metric-value success">42</span>
               </div>
               <div class="metric">
-                <span class="metric-label">Idle alerts</span>
-                <span class="metric-value warning">4</span>
+                <span class="metric-label">Alertas por atender</span>
+                <span class="metric-value warning">6</span>
               </div>
               <div class="sparkline">
                 <span style="--p: 38"></span>
@@ -95,193 +95,196 @@
               </div>
             </div>
             <div class="floating-card">
-              <p>AI predicts a demand spike in the northeast corridor. Suggested action: reposition 8 EV units by 06:00.</p>
+              <p>Alerta: Unidad AGS-24 salió de geocerca a las 15:42. Se sugiere activar centinelas y notificar al despacho.</p>
             </div>
           </div>
         </div>
       </section>
 
-      <section class="section" id="solutions">
+      <section class="section" id="nosotros">
+        <div class="container split">
+          <div class="section-heading">
+            <span class="eyebrow">Nosotros</span>
+            <h2>Innovación mexicana en rastreo y control de activos</h2>
+            <p>
+              Rainde surge a finales de 2008 ofreciendo servicios de diseño, implementación y comercialización de soluciones integrales de rastreo y control de activos móviles en tiempo real para la transportación de personas, valores y bienes.
+            </p>
+            <p>
+              Somos una empresa de tecnologías de la información que desarrolla sistemas inalámbricos con creatividad y flexibilidad, capaces de adaptarse a los procesos de cada negocio y respaldados por investigación aplicada en telecomunicaciones.
+            </p>
+          </div>
+          <div class="platform-card">
+            <h3>Misión</h3>
+            <p>Proporcionar sistemas de administración y control de activos en tiempo real que protejan los valores y recursos de nuestros clientes sin importar su ubicación.</p>
+            <h3>Política de calidad</h3>
+            <p>Aseguramos la disponibilidad de nuestros servicios en cualquier lugar donde nuestros clientes cuenten con conexión a internet.</p>
+            <div class="tags">
+              <span>Servicio</span>
+              <span>Respeto</span>
+              <span>Responsabilidad</span>
+              <span>Creatividad</span>
+              <span>Tolerancia</span>
+              <span>Integridad</span>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="section" id="soluciones">
         <div class="container">
           <div class="section-heading">
-            <span class="eyebrow">Solutions</span>
-            <h2>Built for the entire fleet lifecycle</h2>
+            <span class="eyebrow">Soluciones</span>
+            <h2>Plataformas y servicios listos para tu flotilla</h2>
             <p>
-              From procurement to predictive maintenance, NovaFleet empowers every
-              team with connected workflows and actionable insights.
+              Integramos administración de viajes, rastreo satelital y soporte especializado para que cada activo se controle en un mismo centro de mando.
             </p>
           </div>
           <div class="grid features">
             <article>
               <div class="icon">
                 <svg viewBox="0 0 24 24" aria-hidden="true">
-                  <path
-                    d="M6 4a2 2 0 110 4 2 2 0 010-4zm12 12a2 2 0 110 4 2 2 0 010-4z"
-                    fill="currentColor"
-                  />
-                  <path
-                    d="M6 8v5a3 3 0 003 3h6a3 3 0 003-3V7"
-                    stroke="currentColor"
-                    stroke-width="1.6"
-                    stroke-linecap="round"
-                  />
+                  <path d="M4 6h16v12H4z" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linejoin="round" />
+                  <path d="M4 10h16" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" />
+                  <path d="M8 14h4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" />
                 </svg>
               </div>
-              <h3>Dynamic Orchestration</h3>
+              <h3>Administración de Flotillas (ERaindeFLEET)</h3>
               <p>
-                Adaptive routing, load optimization, and driver assistance backed by
-                real-time telemetry and AI recommendations.
+                Optimiza viajes, personal, finanzas, despachos y proveedores con un sistema configurable diseñado para tus procesos.
               </p>
               <ul>
-                <li>Automated dispatch adjustments</li>
-                <li>Energy-aware route planning</li>
-                <li>Driver collaboration app</li>
+                <li>Acceso web seguro con reportes imprimibles.</li>
+                <li>Alertas automatizadas y seguimiento puntual de cada viaje.</li>
+                <li>Escalabilidad que crece con tus operaciones.</li>
               </ul>
             </article>
             <article>
               <div class="icon">
                 <svg viewBox="0 0 24 24" aria-hidden="true">
-                  <path
-                    d="M12 3l7 3v5.2c0 4.1-2.7 7.9-6.5 9.1a1.3 1.3 0 01-.9 0C7.7 19.1 5 15.3 5 11.2V6l7-3z"
-                    fill="none"
-                    stroke="currentColor"
-                    stroke-width="1.6"
-                    stroke-linejoin="round"
-                  />
-                  <path
-                    d="M10 12l1.8 1.8L15 10.6"
-                    fill="none"
-                    stroke="currentColor"
-                    stroke-width="1.6"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                  />
+                  <circle cx="12" cy="12" r="9" fill="none" stroke="currentColor" stroke-width="1.6" />
+                  <path d="M12 7v5l3 3" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" />
                 </svg>
               </div>
-              <h3>Risk & Compliance</h3>
+              <h3>Rastreo Inteligente</h3>
               <p>
-                Meet regulatory requirements effortlessly with automated reporting,
-                incident workflows, and secure digital documentation.
+                Monitorea en tiempo real cualquier activo, vehículo o maquinaria con historial, ubicación actual y alertas fuera de ruta.
               </p>
               <ul>
-                <li>Digital inspection trails</li>
-                <li>AI video safety analysis</li>
-                <li>Policy and training automation</li>
+                <li>Geocercas, puntos de interés y control de usuarios.</li>
+                <li>Conexión directa con ECM y control de combustible.</li>
+                <li>Reportes de recorridos y rendimientos reales.</li>
               </ul>
             </article>
             <article>
               <div class="icon">
                 <svg viewBox="0 0 24 24" aria-hidden="true">
-                  <path
-                    d="M13 2l-8 12h6l-2 8 8-12h-6z"
-                    fill="none"
-                    stroke="currentColor"
-                    stroke-width="1.6"
-                    stroke-linejoin="round"
-                    stroke-linecap="round"
-                  />
+                  <path d="M4 4h6v6H4zM14 4h6v6h-6zM4 14h6v6H4z" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linejoin="round" />
+                  <path d="M14 14l6 6" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" />
                 </svg>
               </div>
-              <h3>Intelligent Maintenance</h3>
+              <h3>Soporte y operación 24/7</h3>
               <p>
-                Predict issues before they impact uptime with sensor fusion,
-                condition-based monitoring, and autonomous service scheduling.
+                Un equipo técnico profesional atiende sistemas, redes e infraestructura con planes ajustados a tus necesidades.
               </p>
               <ul>
-                <li>Unified asset health scores</li>
-                <li>Predictive parts ordering</li>
-                <li>Technician workflow hub</li>
+                <li>Asistencia eficiente para tu parque tecnológico.</li>
+                <li>Opciones viables según tu operación.</li>
+                <li>Atención sin límites, disponible 24 x 7.</li>
               </ul>
             </article>
           </div>
         </div>
       </section>
 
-      <section class="section accent" id="platform">
+      <section class="section accent" id="plataforma">
         <div class="container split">
           <div>
-            <span class="eyebrow">Platform</span>
-            <h2>Secure, cloud-native, built to scale globally</h2>
+            <span class="eyebrow">RaindeFLEET</span>
+            <h2>Un sistema integral para administrar cada detalle de tu flotilla</h2>
             <p>
-              Deploy in days, not months. Our composable platform integrates with
-              your ERP, telematics, and data lakes while meeting the highest
-              standards for security and privacy.
+              ERaindeFLEET reúne seguridad, rapidez y facilidad de uso para automatizar la administración de viajes, liquidaciones y recursos desde un entorno web.
             </p>
             <ul class="checklist">
-              <li>Open API and 400+ pre-built integrations</li>
-              <li>Multi-region redundancy with 24/7 SRE coverage</li>
-              <li>Granular role-based access controls</li>
-              <li>ISO 27001, SOC 2 Type II, and GDPR compliant</li>
+              <li>Seguridad en el acceso y resguardo de datos.</li>
+              <li>Crecimiento sin límites conforme escala tu operación.</li>
+              <li>Autonomía y centinelas para monitorear cada unidad.</li>
+              <li>Herramientas de despacho con reportes en tiempo real y correo electrónico.</li>
+              <li>Alertas contra desviaciones de ETA y eventos críticos.</li>
+              <li>Finanzas, liquidaciones y mantenimiento preventivo integrados.</li>
+              <li>Gestión completa de proveedores y almacenes.</li>
             </ul>
           </div>
           <div class="platform-card">
-            <h3>Unified Control Tower</h3>
-            <p>Curate dashboards and automate alerts without touching code.</p>
+            <h3>Componentes clave</h3>
+            <p>
+              Configura módulos personalizados y mantén la trazabilidad de viajes, operadores y unidades desde cualquier dispositivo conectado a internet.
+            </p>
             <div class="tags">
-              <span>Zero-code automation</span>
-              <span>Data lakehouse</span>
-              <span>Observability</span>
-              <span>Edge analytics</span>
+              <span>Viajes</span>
+              <span>Personal</span>
+              <span>Despacho</span>
+              <span>Finanzas</span>
+              <span>Proveedores</span>
+              <span>Almacenes</span>
             </div>
-            <div class="avatars" aria-label="Customer logos">
-              <span>Arcturus Logistics</span>
-              <span>BlueOrbit Energy</span>
-              <span>MetroLink Transit</span>
+            <div class="avatars" aria-label="Beneficios de RaindeFLEET">
+              <span>Acceso web seguro</span>
+              <span>Reportes imprimibles</span>
+              <span>Alertas automatizadas</span>
             </div>
           </div>
         </div>
       </section>
 
-      <section class="section" id="insights">
+      <section class="section" id="rastreointeligente">
         <div class="container">
           <div class="section-heading">
-            <span class="eyebrow">Insights</span>
-            <h2>Decision intelligence for every role</h2>
+            <span class="eyebrow">Rastreo Inteligente</span>
+            <h2>Monitoreo satelital con información precisa y accionable</h2>
             <p>
-              Align executives, dispatchers, and technicians with live KPIs and
-              predictive forecasts customized to their objectives.
+              Visualiza la ubicación actual, el historial de recorridos y los eventos críticos de cada activo para reaccionar a tiempo y proteger tu operación.
             </p>
           </div>
           <div class="grid insights-grid">
             <article>
-              <h3>Executives</h3>
-              <p>Portfolio-level dashboards unify cost, sustainability, and service metrics.</p>
+              <h3>Historial y análisis</h3>
+              <p>Consulta recorridos reales y rendimientos para documentar cada trayecto.</p>
               <dl>
                 <div>
-                  <dt>Strategic Score</dt>
-                  <dd>+12% YoY efficiency gains</dd>
+                  <dt>Historial</dt>
+                  <dd>Trayectorias completas con tiempos y distancias.</dd>
                 </div>
                 <div>
-                  <dt>Carbon Intensity</dt>
-                  <dd>Down 28% after EV rollout</dd>
+                  <dt>Reportes</dt>
+                  <dd>Información lista para exportar y compartir.</dd>
                 </div>
               </dl>
             </article>
             <article>
-              <h3>Operations</h3>
-              <p>Real-time load visibility and crew coordination for complex multi-stop routes.</p>
+              <h3>Control operativo</h3>
+              <p>Define reglas por geocercas y recibe alertas ante desvíos o paradas no previstas.</p>
               <dl>
                 <div>
-                  <dt>Fill Rate</dt>
-                  <dd>97% network average</dd>
+                  <dt>Geocercas</dt>
+                  <dd>Delimita zonas seguras y puntos de interés.</dd>
                 </div>
                 <div>
-                  <dt>Exceptions Resolved</dt>
-                  <dd>54% automated in-platform</dd>
+                  <dt>Fuera de ruta</dt>
+                  <dd>Centinelas que notifican variaciones en la ruta planeada.</dd>
                 </div>
               </dl>
             </article>
             <article>
-              <h3>Field Teams</h3>
-              <p>Mobile-first experiences streamline inspections, work orders, and compliance.</p>
+              <h3>Integración vehicular</h3>
+              <p>Conecta la plataforma al ECM para controlar combustible y desempeño.</p>
               <dl>
                 <div>
-                  <dt>Work Order SLA</dt>
-                  <dd>4.5 hours median time-to-resolution</dd>
+                  <dt>ECM</dt>
+                  <dd>Lectura directa de datos del motor y diagnósticos.</dd>
                 </div>
                 <div>
-                  <dt>Safety Coaching</dt>
-                  <dd>38% fewer incidents</dd>
+                  <dt>Combustible</dt>
+                  <dd>Seguimiento de consumo real con alertas configurables.</dd>
                 </div>
               </dl>
             </article>
@@ -289,50 +292,178 @@
         </div>
       </section>
 
-      <section class="section testimonials">
+      <section class="section" id="servicios">
         <div class="container">
           <div class="section-heading">
-            <span class="eyebrow">Customer stories</span>
-            <h2>Trusted by industry leaders transforming mobility</h2>
+            <span class="eyebrow">Servicios profesionales</span>
+            <h2>Acompañamiento experto para tu operación tecnológica</h2>
+            <p>
+              Complementa tus sistemas con consultoría, integración y soluciones de infraestructura que mantienen tus procesos siempre disponibles.
+            </p>
+          </div>
+          <div class="grid features">
+            <article>
+              <div class="icon">
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M12 3l8 4v6c0 4.4-3.6 7.9-8 8-4.4-.1-8-3.6-8-8V7z" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linejoin="round" />
+                  <path d="M9 12l2 2 4-4" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" />
+                </svg>
+              </div>
+              <h3>Consultoría y diseño</h3>
+              <p>
+                Diseñamos, analizamos y reingenierizamos sistemas para que cada solución se ajuste a tu estrategia de negocio.
+              </p>
+              <ul>
+                <li>Diseño de soluciones a la medida.</li>
+                <li>Reingeniería de sistemas existentes.</li>
+                <li>Análisis funcional y técnico especializado.</li>
+              </ul>
+            </article>
+            <article>
+              <div class="icon">
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M5 8h14v12H5z" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linejoin="round" />
+                  <path d="M9 4h6v4H9z" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linejoin="round" />
+                  <path d="M9 12h6" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" />
+                </svg>
+              </div>
+              <h3>Infraestructura a la medida</h3>
+              <p>
+                Garantizamos seguridad y estabilidad para que tus servicios informáticos respondan a la demanda del mercado.
+              </p>
+              <ul>
+                <li>Evaluaciones de seguridad y disponibilidad.</li>
+                <li>Implementaciones alineadas a tus procesos.</li>
+                <li>Operaciones eficientes con calidad comprobada.</li>
+              </ul>
+            </article>
+            <article>
+              <div class="icon">
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M3 5h18v14H3z" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linejoin="round" />
+                  <path d="M7 9h10v6H7z" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linejoin="round" />
+                  <path d="M12 9v6" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" />
+                </svg>
+              </div>
+              <h3>Desarrollo e integración</h3>
+              <p>
+                Construimos software a la medida e integramos sistemas para que los datos se capturen una sola vez y lleguen a toda tu organización.
+              </p>
+              <ul>
+                <li>Automatización de procesos críticos.</li>
+                <li>Conectividad entre plataformas existentes.</li>
+                <li>Escenarios personalizables para cada área.</li>
+              </ul>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section class="section" id="paquetes">
+        <div class="container">
+          <div class="section-heading">
+            <span class="eyebrow">Paquetes web</span>
+            <h2>Presencia digital lista para impulsar tu negocio</h2>
+            <p>
+              Selecciona la opción que mejor se adapte a tu empresa o arma una propuesta personalizada con los módulos que necesites.
+            </p>
+          </div>
+          <div class="grid insights-grid">
+            <article>
+              <h3>Paquete Mi Empresa</h3>
+              <p>Todo lo necesario para iniciar tu sitio corporativo.</p>
+              <ul>
+                <li>1 año de publicación en internet.</li>
+                <li>Dominio incluido y diseño de 7 módulos informativos.</li>
+                <li>Correo empresarial para tu equipo.</li>
+              </ul>
+            </article>
+            <article>
+              <h3>Paquete Mi Negocio Web</h3>
+              <p>Una experiencia optimizada para clientes en cualquier dispositivo.</p>
+              <ul>
+                <li>1 año de hospedaje y dominio administrado.</li>
+                <li>7 módulos informativos con diseño profesional.</li>
+                <li>Correos empresariales y versión móvil del sitio.</li>
+              </ul>
+            </article>
+            <article>
+              <h3>Arma tu Paquete</h3>
+              <p>Cotiza un proyecto a la medida con los componentes que requieres.</p>
+              <ul>
+                <li>Módulos informativos, galerías y formularios personalizables.</li>
+                <li>Banners animados, sistemas de administración y perfiles de usuarios.</li>
+                <li>Acompañamiento para publicar y gestionar tu sitio.</li>
+              </ul>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section class="section testimonials" id="valores">
+        <div class="container">
+          <div class="section-heading">
+            <span class="eyebrow">Valores</span>
+            <h2>Nuestro compromiso con clientes y colaboradores</h2>
           </div>
           <div class="carousel" role="list">
             <article class="testimonial" role="listitem">
-              <p>
-                “NovaFleet accelerated our sustainability roadmap by giving us unified
-                data across EVs and combustion assets. Our teams now act on the same
-                truth.”
-              </p>
+              <p>Respondemos a las necesidades de nuestros clientes en el momento en que lo requieren.</p>
               <div class="author">
-                <span class="avatar" aria-hidden="true">MB</span>
+                <span class="avatar" aria-hidden="true">S</span>
                 <div>
-                  <strong>Mia Benton</strong>
-                  <span>Chief Innovation Officer, MetroLink Transit</span>
+                  <strong>Servicio</strong>
+                  <span>Disponibilidad y acompañamiento oportuno.</span>
                 </div>
               </div>
             </article>
             <article class="testimonial" role="listitem">
-              <p>
-                “The automation playbooks reduced manual dispatch tasks by 60%. We
-                scale faster with fewer overtime hours and happier customers.”
-              </p>
+              <p>Creemos en la importancia de la sociedad, el medio ambiente y el respeto a las leyes.</p>
               <div class="author">
-                <span class="avatar" aria-hidden="true">AR</span>
+                <span class="avatar" aria-hidden="true">R</span>
                 <div>
-                  <strong>André Ruiz</strong>
-                  <span>Director of Operations, Arcturus Logistics</span>
+                  <strong>Respeto</strong>
+                  <span>Diversidad de ideas que fortalece a nuestro equipo.</span>
                 </div>
               </div>
             </article>
             <article class="testimonial" role="listitem">
-              <p>
-                “We trust NovaFleet with our mission-critical infrastructure because
-                of the robust security model and relentless uptime.”
-              </p>
+              <p>Cumplimos nuestros compromisos con entusiasmo y constancia para alcanzar las metas.</p>
               <div class="author">
-                <span class="avatar" aria-hidden="true">LS</span>
+                <span class="avatar" aria-hidden="true">R</span>
                 <div>
-                  <strong>Lina Shah</strong>
-                  <span>VP Technology, BlueOrbit Energy</span>
+                  <strong>Responsabilidad</strong>
+                  <span>Palabra y acciones alineadas a cada proyecto.</span>
+                </div>
+              </div>
+            </article>
+            <article class="testimonial" role="listitem">
+              <p>Fomentamos ideas que rompen paradigmas y enriquecen nuestro trabajo diario.</p>
+              <div class="author">
+                <span class="avatar" aria-hidden="true">C</span>
+                <div>
+                  <strong>Creatividad</strong>
+                  <span>Innovación continua para nuestros clientes.</span>
+                </div>
+              </div>
+            </article>
+            <article class="testimonial" role="listitem">
+              <p>Promovemos la empatía y la cooperación para lograr comunicación y trabajo en equipo efectivos.</p>
+              <div class="author">
+                <span class="avatar" aria-hidden="true">T</span>
+                <div>
+                  <strong>Tolerancia</strong>
+                  <span>Relaciones que suman a cada proyecto.</span>
+                </div>
+              </div>
+            </article>
+            <article class="testimonial" role="listitem">
+              <p>Buscamos honestidad y congruencia en cada relación laboral y comercial.</p>
+              <div class="author">
+                <span class="avatar" aria-hidden="true">I</span>
+                <div>
+                  <strong>Integridad</strong>
+                  <span>Trabajo digno dentro del marco de la ley.</span>
                 </div>
               </div>
             </article>
@@ -340,74 +471,74 @@
         </div>
       </section>
 
-      <section class="section cta" id="demo">
+      <section class="section cta" id="contacto">
         <div class="container">
           <div class="cta-card">
             <div>
-              <span class="eyebrow">Next steps</span>
-              <h2>See NovaFleet in action</h2>
+              <span class="eyebrow">Contacto</span>
+              <h2>Conversemos sobre tus necesidades</h2>
               <p>
-                Get a tailored walkthrough of the platform with one of our specialists
-                and discover how we can accelerate your fleet modernization goals.
+                Solicita una demostración personalizada o comparte los retos de tu operación. Nuestro equipo te ayudará a elegir la solución adecuada.
               </p>
+              <p>Teléfono oficina: <strong>449 996 7500</strong><br />Correo: <strong>ventas@rainde.net</strong></p>
             </div>
             <form class="cta-form" action="#" method="post">
               <div class="form-row">
-                <label for="name">Full name</label>
-                <input type="text" id="name" name="name" placeholder="Alex Morgan" required />
+                <label for="name">Nombre completo</label>
+                <input type="text" id="name" name="name" placeholder="Nombre y apellido" required />
               </div>
               <div class="form-row">
-                <label for="email">Work email</label>
-                <input type="email" id="email" name="email" placeholder="alex@company.com" required />
+                <label for="email">Correo electrónico</label>
+                <input type="email" id="email" name="email" placeholder="correo@empresa.com" required />
               </div>
               <div class="form-row">
-                <label for="company">Company</label>
-                <input type="text" id="company" name="company" placeholder="Company name" />
+                <label for="company">Empresa</label>
+                <input type="text" id="company" name="company" placeholder="Nombre de la empresa" />
               </div>
               <div class="form-row">
-                <label for="fleet-size">Fleet size</label>
+                <label for="fleet-size">Tamaño de la flotilla</label>
                 <select id="fleet-size" name="fleet-size">
-                  <option value="" disabled selected>Select an option</option>
-                  <option value="1-50">1-50 vehicles</option>
-                  <option value="51-250">51-250 vehicles</option>
-                  <option value="251-1000">251-1000 vehicles</option>
-                  <option value="1000+">1000+ vehicles</option>
+                  <option value="" disabled selected>Selecciona una opción</option>
+                  <option value="1-50">1-50 vehículos</option>
+                  <option value="51-250">51-250 vehículos</option>
+                  <option value="251-1000">251-1000 vehículos</option>
+                  <option value="1000+">Más de 1000 vehículos</option>
                 </select>
               </div>
-              <button type="submit" class="button primary">Request demo</button>
+              <button type="submit" class="button primary">Enviar mensaje</button>
             </form>
           </div>
         </div>
       </section>
     </main>
 
-    <footer class="site-footer" id="contact">
+    <footer class="site-footer">
       <div class="container">
         <div class="footer-brand">
-          <span class="logo-mark">N</span>
+          <span class="logo-mark">R</span>
           <div>
-            <span class="logo-text">NovaFleet</span>
-            <p>Modern intelligence for connected mobility.</p>
+            <span class="logo-text">Rainde</span>
+            <p>Sistemas de administración de flotillas y rastreo inteligente.</p>
           </div>
         </div>
         <div class="footer-links">
           <div>
-            <h4>Company</h4>
-            <a href="#">About</a>
-            <a href="#">Careers</a>
-            <a href="#">Press</a>
+            <h4>Compañía</h4>
+            <a href="#nosotros">¿Quiénes somos?</a>
+            <a href="#valores">Valores</a>
+            <a href="#contacto">Contacto</a>
           </div>
           <div>
-            <h4>Platform</h4>
-            <a href="#solutions">Features</a>
-            <a href="#platform">Architecture</a>
-            <a href="#insights">Analytics</a>
+            <h4>Soluciones</h4>
+            <a href="#soluciones">Administración de flotillas</a>
+            <a href="#plataforma">RaindeFLEET</a>
+            <a href="#rastreointeligente">Rastreo inteligente</a>
           </div>
           <div>
-            <h4>Resources</h4>
-            <a href="#insights">Blog</a>
-            <a href="#">Security</a>
-            <a href="#">Status</a>
+            <h4>Servicios</h4>
+            <a href="#servicios">Consultoría</a>
+            <a href="#servicios">Infraestructura</a>
+            <a href="#paquetes">Paquetes web</a>
           </div>
         </div>
         <div class="footer-meta">
@@ -422,12 +553,12 @@
               <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M23.5 6.2s-.23-1.64-.95-2.36c-.9-.95-1.9-.96-2.36-1.02-3.3-.24-8.24-.24-8.24-.24h-.01s-4.94 0-8.24.24c-.46.06-1.46.07-2.36 1.02-.72.72-.95 2.36-.95 2.36s-.24 1.92-.24 3.84v1.8c0 1.92.24 3.84.24 3.84s.23 1.64.95 2.36c.9.95 2.08.92 2.61 1.02 1.9.18 8 .24 8 .24s4.94-.01 8.24-.25c.46-.06 1.46-.07 2.36-1.02.72-.72.95-2.36.95-2.36s.24-1.92.24-3.84v-1.8c0-1.92-.24-3.84-.24-3.84zm-13.91 7.43v-6.16l6.16 3.08-6.16 3.08z" /></svg>
             </a>
           </div>
-          <p class="copyright">© <span id="year"></span> NovaFleet Solutions. All rights reserved.</p>
+          <p class="copyright">© <span id="year"></span> Rainde. Todos los derechos reservados.</p>
         </div>
       </div>
     </footer>
 
-    <button class="scroll-top" aria-label="Scroll to top">
+    <button class="scroll-top" aria-label="Ir arriba">
       <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 4l-8 8h5v8h6v-8h5z" /></svg>
     </button>
 

--- a/styles.css
+++ b/styles.css
@@ -1,17 +1,17 @@
 :root {
   color-scheme: light dark;
-  --bg: #07080d;
-  --bg-alt: #0f111a;
-  --bg-accent: linear-gradient(135deg, rgba(66, 133, 244, 0.15), rgba(23, 196, 145, 0.15));
+  --bg: #05060c;
+  --bg-alt: #0d101a;
+  --bg-accent: linear-gradient(135deg, rgba(0, 91, 150, 0.18), rgba(240, 195, 44, 0.18));
   --surface: rgba(255, 255, 255, 0.07);
   --surface-strong: rgba(255, 255, 255, 0.12);
   --text: #f5f7ff;
   --text-muted: rgba(245, 247, 255, 0.68);
-  --primary: #4f8cff;
-  --primary-strong: #2f6bff;
-  --accent: #1ed89e;
+  --primary: #005b96;
+  --primary-strong: #004274;
+  --accent: #f0c32c;
   --warning: #ffb347;
-  --success: #37e2b2;
+  --success: #36d1a0;
   --border: rgba(255, 255, 255, 0.08);
   --shadow: 0 30px 80px rgba(15, 17, 26, 0.45);
   --container-width: min(1120px, 92vw);
@@ -24,8 +24,8 @@
 
 body {
   margin: 0;
-  background: radial-gradient(circle at 20% 20%, rgba(79, 140, 255, 0.18), transparent 55%),
-    radial-gradient(circle at 80% 0%, rgba(23, 196, 145, 0.2), transparent 60%),
+  background: radial-gradient(circle at 20% 20%, rgba(0, 91, 150, 0.2), transparent 55%),
+    radial-gradient(circle at 80% 0%, rgba(240, 195, 44, 0.18), transparent 60%),
     var(--bg);
   color: var(--text);
   line-height: 1.6;
@@ -127,13 +127,13 @@ section {
 
 .button.primary {
   background: linear-gradient(135deg, var(--primary), var(--accent));
-  box-shadow: 0 15px 35px rgba(79, 140, 255, 0.35);
+  box-shadow: 0 15px 35px rgba(0, 91, 150, 0.35);
   color: #0a1022;
 }
 
 .button.primary:hover {
   transform: translateY(-2px);
-  box-shadow: 0 25px 45px rgba(79, 140, 255, 0.4);
+  box-shadow: 0 25px 45px rgba(0, 91, 150, 0.45);
 }
 
 .button.ghost {
@@ -185,7 +185,7 @@ section {
   border-radius: 12px;
   display: grid;
   place-items: center;
-  background: linear-gradient(135deg, rgba(79, 140, 255, 0.2), rgba(55, 226, 178, 0.25));
+  background: linear-gradient(135deg, rgba(0, 91, 150, 0.24), rgba(240, 195, 44, 0.32));
   border: 1px solid rgba(255, 255, 255, 0.1);
   backdrop-filter: blur(10px);
 }
@@ -313,7 +313,7 @@ section {
   padding: 1.75rem;
   border-radius: 24px;
   backdrop-filter: blur(20px);
-  background: linear-gradient(155deg, rgba(79, 140, 255, 0.26), rgba(7, 8, 13, 0.9));
+  background: linear-gradient(155deg, rgba(0, 91, 150, 0.28), rgba(7, 8, 13, 0.9));
   border: 1px solid rgba(255, 255, 255, 0.15);
   box-shadow: var(--shadow);
 }
@@ -375,7 +375,7 @@ section {
   padding: 1.25rem 1.5rem;
   border-radius: 18px;
   background: rgba(15, 17, 26, 0.9);
-  border: 1px solid rgba(79, 140, 255, 0.35);
+  border: 1px solid rgba(0, 91, 150, 0.45);
   box-shadow: 0 20px 50px rgba(7, 8, 13, 0.45);
   font-size: 0.95rem;
   color: rgba(245, 247, 255, 0.85);
@@ -407,13 +407,13 @@ section {
   inset: -40% auto auto -30%;
   width: 120px;
   height: 120px;
-  background: radial-gradient(circle, rgba(79, 140, 255, 0.35), transparent 65%);
+  background: radial-gradient(circle, rgba(0, 91, 150, 0.35), transparent 65%);
   z-index: 0;
 }
 
 .features article:hover {
   transform: translateY(-6px);
-  border-color: rgba(79, 140, 255, 0.35);
+  border-color: rgba(0, 91, 150, 0.45);
 }
 
 .features .icon {
@@ -422,8 +422,8 @@ section {
   border-radius: 16px;
   display: grid;
   place-items: center;
-  background: rgba(79, 140, 255, 0.15);
-  border: 1px solid rgba(79, 140, 255, 0.3);
+  background: rgba(0, 91, 150, 0.18);
+  border: 1px solid rgba(240, 195, 44, 0.35);
   margin-bottom: 1.5rem;
   z-index: 1;
 }
@@ -486,14 +486,14 @@ section {
   height: 14px;
   border-radius: 4px;
   background: linear-gradient(135deg, var(--primary), var(--accent));
-  box-shadow: 0 10px 20px rgba(31, 199, 154, 0.4);
+  box-shadow: 0 10px 20px rgba(240, 195, 44, 0.35);
 }
 
 .platform-card {
   padding: 2.25rem;
   border-radius: 24px;
   border: 1px solid rgba(255, 255, 255, 0.12);
-  background: linear-gradient(155deg, rgba(79, 140, 255, 0.18), rgba(7, 8, 13, 0.85));
+  background: linear-gradient(155deg, rgba(0, 91, 150, 0.2), rgba(7, 8, 13, 0.85));
   box-shadow: var(--shadow);
 }
 
@@ -552,7 +552,7 @@ section {
 }
 
 .testimonials {
-  background: linear-gradient(160deg, rgba(79, 140, 255, 0.18), rgba(12, 14, 24, 0.95));
+  background: linear-gradient(160deg, rgba(0, 91, 150, 0.22), rgba(12, 14, 24, 0.95));
 }
 
 .carousel {
@@ -588,14 +588,14 @@ section {
   border-radius: 16px;
   display: grid;
   place-items: center;
-  background: rgba(79, 140, 255, 0.2);
-  border: 1px solid rgba(79, 140, 255, 0.35);
+  background: rgba(0, 91, 150, 0.22);
+  border: 1px solid rgba(240, 195, 44, 0.45);
   font-weight: 600;
   letter-spacing: 0.08em;
 }
 
 .section.cta {
-  background: radial-gradient(circle at top right, rgba(79, 140, 255, 0.24), transparent 55%),
+  background: radial-gradient(circle at top right, rgba(0, 91, 150, 0.3), transparent 55%),
     rgba(7, 8, 13, 0.92);
 }
 
@@ -642,8 +642,8 @@ select {
 input:focus,
 select:focus {
   outline: none;
-  border-color: rgba(79, 140, 255, 0.6);
-  box-shadow: 0 0 0 3px rgba(79, 140, 255, 0.25);
+  border-color: rgba(0, 91, 150, 0.6);
+  box-shadow: 0 0 0 3px rgba(240, 195, 44, 0.25);
 }
 
 .site-footer {
@@ -703,8 +703,8 @@ select:focus {
 }
 
 .socials a:hover {
-  border-color: rgba(79, 140, 255, 0.5);
-  background: rgba(79, 140, 255, 0.18);
+  border-color: rgba(0, 91, 150, 0.55);
+  background: rgba(0, 91, 150, 0.2);
 }
 
 .socials svg {
@@ -731,7 +731,7 @@ select:focus {
   display: grid;
   place-items: center;
   cursor: pointer;
-  box-shadow: 0 20px 40px rgba(79, 140, 255, 0.35);
+  box-shadow: 0 20px 40px rgba(0, 91, 150, 0.35);
   opacity: 0;
   pointer-events: none;
   transform: translateY(12px);

--- a/styles.css
+++ b/styles.css
@@ -147,6 +147,10 @@ section {
   transform: translateY(-2px);
 }
 
+.button.more-info {
+  margin-top: 1.5rem;
+}
+
 .site-header {
   position: sticky;
   top: 0;
@@ -179,15 +183,13 @@ section {
   text-transform: uppercase;
 }
 
-.logo-mark {
-  width: 42px;
-  height: 42px;
+.logo-image {
+  width: 140px;
+  height: 48px;
+  object-fit: contain;
   border-radius: 12px;
-  display: grid;
-  place-items: center;
-  background: linear-gradient(135deg, rgba(0, 91, 150, 0.24), rgba(240, 195, 44, 0.32));
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  backdrop-filter: blur(10px);
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.4);
+  border: 1px solid rgba(255, 255, 255, 0.15);
 }
 
 .site-nav {
@@ -390,6 +392,10 @@ section {
   grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
 }
 
+.services-grid {
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
 .features article {
   padding: 2.25rem;
   border-radius: 24px;
@@ -473,6 +479,10 @@ section {
   color: var(--text-muted);
 }
 
+.checklist.columns {
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
 .checklist li {
   display: flex;
   align-items: flex-start;
@@ -520,6 +530,42 @@ section {
   font-weight: 500;
 }
 
+.platform-note {
+  margin-top: 1.5rem;
+  color: rgba(245, 247, 255, 0.75);
+  font-size: 0.95rem;
+  line-height: 1.6;
+}
+
+.values-grid {
+  display: grid;
+  gap: clamp(1.8rem, 3vw, 2.8rem);
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.values-grid article {
+  padding: 2.25rem;
+  border-radius: 20px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(255, 255, 255, 0.04);
+  backdrop-filter: blur(10px);
+}
+
+.values-grid ul {
+  list-style: none;
+  margin: 1.5rem 0 0;
+  padding: 0;
+  display: grid;
+  gap: 1rem;
+  color: var(--text-muted);
+}
+
+.values-grid ul li {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
 .insights-grid {
   grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
 }
@@ -549,49 +595,6 @@ section {
   margin: 0;
   font-size: 1.1rem;
   color: var(--text);
-}
-
-.testimonials {
-  background: linear-gradient(160deg, rgba(0, 91, 150, 0.22), rgba(12, 14, 24, 0.95));
-}
-
-.carousel {
-  display: grid;
-  gap: 1.8rem;
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-}
-
-.testimonial {
-  padding: 2rem;
-  border-radius: 22px;
-  background: rgba(7, 8, 13, 0.65);
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  backdrop-filter: blur(18px);
-  box-shadow: 0 25px 50px rgba(7, 8, 13, 0.35);
-}
-
-.testimonial p {
-  font-size: 1.05rem;
-  color: rgba(245, 247, 255, 0.85);
-}
-
-.author {
-  margin-top: 1.6rem;
-  display: flex;
-  align-items: center;
-  gap: 1rem;
-}
-
-.avatar {
-  width: 52px;
-  height: 52px;
-  border-radius: 16px;
-  display: grid;
-  place-items: center;
-  background: rgba(0, 91, 150, 0.22);
-  border: 1px solid rgba(240, 195, 44, 0.45);
-  font-weight: 600;
-  letter-spacing: 0.08em;
 }
 
 .section.cta {
@@ -629,7 +632,8 @@ label {
 }
 
 input,
-select {
+select,
+textarea {
   padding: 0.75rem 1rem;
   border-radius: 12px;
   border: 1px solid rgba(255, 255, 255, 0.16);
@@ -640,7 +644,8 @@ select {
 }
 
 input:focus,
-select:focus {
+select:focus,
+textarea:focus {
   outline: none;
   border-color: rgba(0, 91, 150, 0.6);
   box-shadow: 0 0 0 3px rgba(240, 195, 44, 0.25);


### PR DESCRIPTION
## Summary
- rewrite the landing page content in Spanish to reflect Rainde's fleet administration, rastreo inteligente, and services offering
- add dedicated sections for RaindeFLEET, servicios profesionales, paquetes web, valores, and contact information with original phone and email details
- refresh the visual theme to use Rainde-inspired colors and accents across interactive elements

## Testing
- not run (static content update)


------
https://chatgpt.com/codex/tasks/task_e_68cae4fe25c483209eb3d58bc5057888